### PR TITLE
Fix hover class typo in Education and CNMSS

### DIFF
--- a/src/components/CNMSS.tsx
+++ b/src/components/CNMSS.tsx
@@ -302,7 +302,7 @@ const CNMSS = () => {
                 initial="hidden"
                 animate={infoInView ? "visible" : "hidden"}
                 variants={cardVariants}
-                className={`p-6 rounded-xl shadow-lg ${darkMode ? 'bg-gray-800 hover:bg-gray-750' : 'bg-white hover:bg-gray-50'} transition-colors duration-300`}
+                className={`p-6 rounded-xl shadow-lg ${darkMode ? 'bg-gray-800 hover:bg-gray-700' : 'bg-white hover:bg-gray-50'} transition-colors duration-300`}
                 whileHover={{ y: -5, transition: { duration: 0.2 } }}
               >
                 <div className={`p-3 rounded-lg mb-4 inline-block ${darkMode ? 'bg-blue-900 text-blue-300' : 'bg-blue-100 text-blue-600'}`}>

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -150,8 +150,8 @@ const Education = () => {
               </motion.div>
               
               {/* Carte de formation */}
-              <motion.div 
-                className={`p-6 rounded-lg shadow-md ${darkMode ? 'bg-gray-800 hover:bg-gray-750' : 'bg-white hover:bg-gray-50'} transition-all duration-300`}
+              <motion.div
+                className={`p-6 rounded-lg shadow-md ${darkMode ? 'bg-gray-800 hover:bg-gray-700' : 'bg-white hover:bg-gray-50'} transition-all duration-300`}
                 whileHover={{ y: -5 }}
               >
                 <div className="flex justify-between items-start">


### PR DESCRIPTION
## Summary
- fix invalid Tailwind class `hover:bg-gray-750` in Education and CNMSS components

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe8490f80832e95e776a2bee60d36