### PR TITLE
Extract age util and add vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "deploy": "gh-pages -d docs"
+    "deploy": "gh-pages -d docs",
+    "test": "vitest"
   },
   "dependencies": {
     "framer-motion": "^11.0.8",
@@ -35,6 +36,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Mail, Github, Linkedin, Code, Database, Server, BookOpen, Users, Globe, Monitor, Shield, Briefcase, Building, Calendar } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
+import { calculateAge } from '../utils/calculateAge';
 
 /**
  * Composant Hero - Section d'accueil du portfolio
@@ -115,17 +116,6 @@ const Hero = () => {
   // Définir les transitions pour les compétences
   const skillHoverTransition = { type: "spring", stiffness: 400, damping: 10 };
 
-  // Calculer l'âge dynamiquement
-  const calculateAge = () => {
-    const birthDate = new Date(2004, 2, 20); // Mois commence à 0 (mars = 2)
-    const today = new Date();
-    let age = today.getFullYear() - birthDate.getFullYear();
-    const m = today.getMonth() - birthDate.getMonth();
-    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
-      age--;
-    }
-    return age;
-  };
 
   return (
     <section id="home" className={`min-h-screen pt-20 flex items-center relative overflow-hidden ${darkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>

--- a/src/utils/calculateAge.test.ts
+++ b/src/utils/calculateAge.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { calculateAge } from './calculateAge';
+
+describe('calculateAge', () => {
+  it('returns correct age for a fixed date', () => {
+    const fixedDate = new Date(2024, 5, 1); // June 1, 2024
+    expect(calculateAge(fixedDate)).toBe(20);
+  });
+});

--- a/src/utils/calculateAge.ts
+++ b/src/utils/calculateAge.ts
@@ -1,0 +1,9 @@
+export function calculateAge(today: Date = new Date()): number {
+  const birthDate = new Date(2004, 2, 20); // Month is 0-indexed
+  let age = today.getFullYear() - birthDate.getFullYear();
+  const m = today.getMonth() - birthDate.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+    age--;
+  }
+  return age;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: './',
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true
+  },
   build: {
     outDir: 'docs',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- extract `calculateAge` helper to `src/utils`
- use the new helper in `Hero`
- configure Vitest via `vite.config.ts` and npm script
- add unit test for the helper

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fecc32f04832eaa6abd2d80c1e079