### PR TITLE
Update repo name in installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ Pour installer ce projet sur votre machine locale, suivez ces étapes :
 
 1. Clonez le dépôt :
    ```bash
-   git clone https://github.com/Hugolmh/portfolio-hugo.git
+   git clone https://github.com/Hugolmh/hugolmh.github.io.git
    ```
 
 2. Accédez au répertoire du projet :
    ```bash
-   cd portfolio-hugo
+   cd hugolmh.github.io
    ```
 
 3. Installez les dépendances :


### PR DESCRIPTION
## Summary
- fix repository name in README installation steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fecc269c8832ebfead2992d6f3622