### PR TITLE
Fix typo in Codah description

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -586,7 +586,7 @@ const Projects = () => {
   const projects: Project[] = [ 
     {
       title: 'Codah',
-      description: 'Application de consultation des droits, accès et habiliataion',
+      description: 'Application de consultation des droits, accès et habilitation',
       image: `${import.meta.env.BASE_URL}Capture.PNG`,
       tags: ['En cours de développement', 'PHP', 'Symfony'],
       features: [


### PR DESCRIPTION
## Summary
- fix a misspelling in Codah project description

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_683fecbe5e3c832e9f53003fefe01f88